### PR TITLE
feat(sqlite): emulate returning on Model.update

### DIFF
--- a/lib/dialects/sqlite/index.js
+++ b/lib/dialects/sqlite/index.js
@@ -49,7 +49,10 @@ SqliteDialect.prototype.supports = _.merge(
       dropConstraint: false
     },
     groupedLimit: false,
-    JSON: true
+    JSON: true,
+    returnValues: {
+      update: true
+    }
   }
 );
 

--- a/lib/dialects/sqlite/query-interface.js
+++ b/lib/dialects/sqlite/query-interface.js
@@ -4,6 +4,8 @@ const sequelizeErrors = require('../../errors');
 const QueryTypes = require('../../query-types');
 const { QueryInterface } = require('../abstract/query-interface');
 const { cloneDeep } = require('../../utils');
+const Utils = require('../../utils');
+const Op = require('../../operators');
 const _ = require('lodash');
 
 /**
@@ -168,6 +170,90 @@ class SQLiteQueryInterface extends QueryInterface {
     await this.sequelize.query('PRAGMA foreign_keys = OFF', options);
     await this._dropAllTables(tableNames, skip, options);
     await this.sequelize.query('PRAGMA foreign_keys = ON', options);
+  }
+
+  /**
+   * SQLite does not support RETURNING on UPDATE. When `options.returning` is set,
+   * select matching rows before the update, run the update, then refetch by primary key.
+   *
+   * @override
+   */
+  async bulkUpdate(tableName, values, identifier, options, attributes) {
+    options = Utils.cloneDeep(options);
+    if (typeof identifier === 'object') identifier = Utils.cloneDeep(identifier);
+
+    if (!options.returning) {
+      return super.bulkUpdate(tableName, values, identifier, options, attributes);
+    }
+
+    const table = _.isObject(tableName) ? tableName : { tableName };
+    const model = options.model || _.find(this.sequelize.modelManager.models, { tableName: table.tableName });
+
+    if (!model) {
+      return super.bulkUpdate(tableName, values, identifier, options, attributes);
+    }
+
+    const primaryKeyAttributes = Object.keys(model.primaryKeys);
+    if (primaryKeyAttributes.length === 0) {
+      throw new Error('Models without a primary key are not supported with returning on update');
+    }
+
+    const selectOptions = {
+      ...options,
+      where: identifier,
+      attributes: primaryKeyAttributes,
+      returning: undefined,
+      type: undefined
+    };
+
+    const rowsBeforeUpdate = await this.select(model, tableName, selectOptions);
+
+    if (rowsBeforeUpdate.length === 0) {
+      return [];
+    }
+
+    const sql = this.queryGenerator.updateQuery(tableName, values, identifier, options, attributes);
+    const updateOptions = {
+      ...options,
+      type: QueryTypes.BULKUPDATE,
+      model
+    };
+
+    await this.sequelize.query(sql, updateOptions);
+
+    let whereByIds;
+    if (primaryKeyAttributes.length === 1) {
+      const primaryKeyAttribute = primaryKeyAttributes[0];
+      whereByIds = {
+        [primaryKeyAttribute]: rowsBeforeUpdate.map(row => row.get(primaryKeyAttribute))
+      };
+    } else {
+      whereByIds = {
+        [Op.or]: rowsBeforeUpdate.map(row => {
+          const entry = {};
+          for (const primaryKeyAttribute of primaryKeyAttributes) {
+            entry[primaryKeyAttribute] = row.get(primaryKeyAttribute);
+          }
+          return entry;
+        })
+      };
+    }
+
+    const refetchOptions = {
+      ...options,
+      where: whereByIds,
+      returning: undefined,
+      type: undefined
+    };
+
+    if (Array.isArray(options.returning)) {
+      const returnAll = options.returning.length === 1 && options.returning[0] === '*';
+      if (!returnAll) {
+        refetchOptions.attributes = options.returning;
+      }
+    }
+
+    return await this.select(model, tableName, refetchOptions);
   }
 
   /**

--- a/test/integration/model/update.test.js
+++ b/test/integration/model/update.test.js
@@ -117,7 +117,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       expect(account.ownerId).to.be.equal(ownerId);
     });
 
-    if (_.get(current.dialect.supports, 'returnValues.returning')) {
+    if (_.get(current.dialect.supports, 'returnValues.returning') || _.get(current.dialect.supports, 'returnValues.update')) {
       it('should return the updated record', async function() {
         const account = await this.Account.create({ ownerId: 2 });
 


### PR DESCRIPTION
SQLite lacks UPDATE RETURNING, so fetch affected rows by primary key before and after the update to match Postgres behavior.

<!-- 
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [ ] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

<!-- Please provide a description of the change here. -->
