### PR TITLE
fix(sqlite): alias field names when refetching update returning rows

### DIFF
--- a/lib/dialects/sqlite/query-interface.js
+++ b/lib/dialects/sqlite/query-interface.js
@@ -198,15 +198,24 @@ class SQLiteQueryInterface extends QueryInterface {
       throw new Error('Models without a primary key are not supported with returning on update');
     }
 
-    const selectOptions = {
-      ...options,
-      where: identifier,
-      attributes: primaryKeyAttributes,
-      returning: undefined,
-      type: undefined
+    const querySelectOptions = _.pick(options, ['transaction', 'paranoid', 'logging', 'benchmark', 'hooks', 'searchPath', 'limit']);
+
+    const buildSelectOptions = (where, selectAttributes) => {
+      const selectOptions = {
+        ...querySelectOptions,
+        where,
+        attributes: selectAttributes
+      };
+      selectOptions.originalAttributes = model._injectDependentVirtualAttributes(selectAttributes);
+      Utils.mapFinderOptions(selectOptions, model);
+      return selectOptions;
     };
 
-    const rowsBeforeUpdate = await this.select(model, tableName, selectOptions);
+    const rowsBeforeUpdate = await this.select(
+      model,
+      tableName,
+      buildSelectOptions(identifier, primaryKeyAttributes)
+    );
 
     if (rowsBeforeUpdate.length === 0) {
       return [];
@@ -239,21 +248,20 @@ class SQLiteQueryInterface extends QueryInterface {
       };
     }
 
-    const refetchOptions = {
-      ...options,
-      where: whereByIds,
-      returning: undefined,
-      type: undefined
-    };
-
-    if (Array.isArray(options.returning)) {
-      const returnAll = options.returning.length === 1 && options.returning[0] === '*';
-      if (!returnAll) {
-        refetchOptions.attributes = options.returning;
-      }
+    let returningAttributes;
+    if (options.returning === true || Array.isArray(options.returning) && options.returning.length === 1 && options.returning[0] === '*') {
+      returningAttributes = Object.keys(model.rawAttributes).filter(key => !model._virtualAttributes.has(key));
+    } else if (Array.isArray(options.returning)) {
+      returningAttributes = options.returning;
+    } else {
+      returningAttributes = Object.keys(model.rawAttributes).filter(key => !model._virtualAttributes.has(key));
     }
 
-    return await this.select(model, tableName, refetchOptions);
+    return await this.select(
+      model,
+      tableName,
+      buildSelectOptions(whereByIds, returningAttributes)
+    );
   }
 
   /**


### PR DESCRIPTION
Map select attributes through mapFinderOptions so columns with a custom field name populate the model attribute correctly.

<!-- 
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [ ] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

<!-- Please provide a description of the change here. -->
